### PR TITLE
Apply patches in after_initialize block so that HealthCheck isn't autoloaded during initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # ServerHealthCheckRailsOsm
-Short description and motivation.
+
+This gem serves 2 roles:
+
+1. Make the server health check URL available via HTTP even when at the application level, config.ssl_only is true.
+2. Make the server health check URL use a different log file than the rest of the application.
+   If the server health check URL is being pinged by monitoring tools every few seconds, it creates a log of noise
+   in the logs.  Instead of logging to production.log like all other requests, it instead logs to health_check.log.
 
 ## Usage
 How to use my plugin.

--- a/lib/server_health_check_rails_osm/engine.rb
+++ b/lib/server_health_check_rails_osm/engine.rb
@@ -4,7 +4,7 @@ module ServerHealthCheckRailsOsm
   class Engine < ::Rails::Engine
     isolate_namespace ServerHealthCheckRailsOsm
 
-    initializer "server_health_check_rails_osm.apply_patches" do |app|
+    config.after_initialize do
       ServerHealthCheckRailsOsm::Patches.apply_patches
     end
 


### PR DESCRIPTION
Auto-loading during initialization results in this warning in Rails 6:

  https://github.com/rails/rails/blob/v6.0.0.rc1/railties/lib/rails/application/finisher.rb#L45